### PR TITLE
Update accessing-datasets.rst

### DIFF
--- a/docs/source/accessing-datasets.rst
+++ b/docs/source/accessing-datasets.rst
@@ -370,6 +370,8 @@ as:
 
    aws s3 ls <yourbucket> --profile <yourprofilename> --endpoint <yourendpoint> --recursive --human-readable --summarize
 
+Recall that if a bucket url is https://mghp.osn.xsede.org/phytoplankton, then <yourbucket> is phytoplankton, and <yourendpoint> is https://mghp.osn.xsede.org.
+
 Third Party Data Management
 ---------------------------
 OSN users may also choose to layer more sophisticated data management applications on top of the S3 API


### PR DESCRIPTION
Defines yourbucket and yourendpoint when used in the aws s3 command, so they don't have to go back and look those up.