### PR TITLE
updated rclone config documentation for the endpoint url

### DIFF
--- a/docs/source/accessing-datasets.rst
+++ b/docs/source/accessing-datasets.rst
@@ -300,7 +300,7 @@ Where:
 * <alias> – nickname of your choice for the allocation
 * <access key> – the access key from the data manager or from the portal
 * <secret key> – the secret key from the data manager of the portal
-* <location> – the location information provided by the data manager or portal
+* <location> – the URL provided by the data manager or portal without the bucket 
 
 An example of a configuration stanza might look like: ::
 

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -18,7 +18,7 @@ To use your own machine for this exercise, you will need git, wget, and gnuplot.
 
 
 Pull down the workflow from GitHub: 
-""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""
 ::
 
 	$ git clone https://github.com/mghpcsim/osn-tutorial.git
@@ -28,7 +28,7 @@ Pull down the workflow from GitHub:
    If you are using the above binder, the Git repo has already been cloned
 
 Change directories to the exercise directory:
-""""""""""""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""""""""""
 
 ::
 
@@ -36,7 +36,7 @@ Change directories to the exercise directory:
 
 
 Workflow step 0, download data from OSN:
-"""""""""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""""""""""
 
 ::
 
@@ -70,7 +70,7 @@ Execute the download data script:
 
 
 Workflow step 1, process the data:
-""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""
 
 ::
 
@@ -103,7 +103,7 @@ Run the process data script:
 
 
 Workflow step 2, visualize the results:
-""""""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""""
 
 ::
 


### PR DESCRIPTION
Added a note to help clarify that the bucket path shouldn't be part of the endpoint URL within the rclone config

Extended the title underline for some of the titles in tutorials because the make was returning errors stating they were too short. 